### PR TITLE
56 document whiteboard presentation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,6 @@
 //
 //= require jquery
 //= require bootstrap
-// = require rails-ujs
+//= require rails-ujs
 //= require spin.js/spin
 //= require_tree .

--- a/app/assets/javascripts/game.coffee
+++ b/app/assets/javascripts/game.coffee
@@ -1,0 +1,12 @@
+
+# Percentage of the window height used as height for the document and whiteboard
+@DOCINFO_DIV_HEIGHT_PERCENTAGE = '50'
+
+# Calculate a percentage of the window height
+@windowHeightPercentage = (requiredPercentage) ->
+  Math.floor($(window).height() / 100 * requiredPercentage)
+
+# Set the height of the 'doc-data' class to a percentage of the window height
+@setDocDataHeight = ->
+  elements = $('.doc-data')
+  e.style.height = windowHeightPercentage(DOCINFO_DIV_HEIGHT_PERCENTAGE) + 'px' for e in elements

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,6 +17,7 @@
 @import "bootstrap";
 @import "font-awesome";
 @import "static_pages";
+@import "games";
 
 header h1{
   position: relative;

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the Games controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.doc-data {
+  overflow-y: auto;
+}

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,4 +1,2 @@
-<blockquote class="document">
-  <h2><%= document.title %></h2>
-  <%= simple_format(document.content) %>
-</blockquote>
+<h2><%= document.title %></h2>
+<%= simple_format document.content %>

--- a/app/views/games/_whiteboard.html.erb
+++ b/app/views/games/_whiteboard.html.erb
@@ -36,4 +36,13 @@
       Duis et elementum elit.
     </p>
   </div>
+
+  <div id="pair_5" class="pair">
+    <p id="question_5" class="question">
+      Aenean bibendum posuere est ut posuere?
+    </p>
+    <p id="answer_5" class="answer">
+      Duis et elementum elit.
+    </p>
+  </div>
 </div>

--- a/app/views/games/_whiteboard.html.erb
+++ b/app/views/games/_whiteboard.html.erb
@@ -1,0 +1,39 @@
+
+<!-- Whiteboard sample -->
+<div id="pairs">
+  <div id="pair_1" class="pair">
+    <p id="question_1" class="question">
+      Aenean bibendum posuere est ut posuere?
+    </p>
+    <p id="answer_1" class="answer">
+      Duis et elementum elit.
+    </p>
+  </div>
+
+  <div id="pair_2" class="pair">
+    <p id="question_2" class="question">
+      Aenean bibendum posuere est ut posuere?
+    </p>
+    <p id="answer_2" class="answer">
+      Duis et elementum elit.
+    </p>
+  </div>
+
+  <div id="pair_3" class="pair">
+    <p id="question_3" class="question">
+      Aenean bibendum posuere est ut posuere?
+    </p>
+    <p id="answer_3" class="answer">
+      Duis et elementum elit.
+    </p>
+  </div>
+
+  <div id="pair_4" class="pair">
+    <p id="question_4" class="question">
+      Aenean bibendum posuere est ut posuere?
+    </p>
+    <p id="answer_4" class="answer">
+      Duis et elementum elit.
+    </p>
+  </div>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,45 +1,59 @@
-<div id="game_attr">
+<div id="game_attr row">
   <table id="attributes">
-    <tr>
-      <th>Game Round: </th>
-      <td><%= @game_player.round %></td>
-    </tr>
-    <tr>
-      <th>Score: </th>
-      <td><%= @game_player.score %></td>
-    </tr>
-    <tr>
-      <th>Role: </th>
-      <td><%= @game_player.role %></td>
-    </tr>
-    <% unless @game_player.role == "judge" %>
       <tr>
-        <th>Questioner of this round: </th>
-        <td>
-          <% if @game_player.questioner? %>
-            Yes
-          <% else %>
-            No
-          <% end %>
-        </td>
+        <th>Game Round: </th>
+        <td><%= @game_player.round %></td>
       </tr>
-    <% end %>
+      <tr>
+        <th>Score: </th>
+        <td><%= @game_player.score %></td>
+      </tr>
+      <tr>
+        <th>Role: </th>
+        <td><%= @game_player.role %></td>
+      </tr>
+      <% unless @game_player.role == "judge" %>
+        <tr>
+          <th>Questioner of this round: </th>
+          <td>
+            <% if @game_player.questioner? %>
+              Yes
+            <% else %>
+              No
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
   </table>
-  <%= button_to "Next Round", game_path, method: :patch, class: "btn btn-lg btn-primary"%>
+   <%= button_to "Next Round", game_path, method: :patch, class: "btn btn-lg btn-primary"%>
 </div>
 
-<% unless @document.nil? %>
-  <div id="document">
-    <header>
-      <h2>Reading Text</h2>
-    </header>
+<%= javascript_tag "$(document).on('DOMContentLoaded', function() { setDocDataHeight(); });" %>
 
-    <%= render @document %>
+<div id='game-info' class="container">
+
+  <div class="titles row">
+    <% unless @document.nil? %>
+    <div class="col-sm-6">
+      <h1>Document</h1>
+    </div>
+    <% end %>
+
+    <div class="<%= 'col-sm-offset-3 ' if @document.nil? %>col-sm-6">
+      <h1>Whiteboard</h1>
+    </div>
   </div>
-<% end %>
 
-<div id="question">
-</div>
+  <div id="doc-info" class="doc-info row">
+    <% unless @document.nil? %>
+    <div id="document" class="doc-data col-sm-6">
+      <%= render @document %>
+    </div>
+    <% end %>
 
-<div id="answer">
+    <div id="whiteboard" class="doc-data <%= 'col-sm-offset-3 ' if @document.nil? %>col-sm-6">
+      <%= render 'games/whiteboard' %>
+    </div>
+  </div>
+
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -29,6 +29,7 @@
 </div>
 
 <%= javascript_tag "$(document).on('DOMContentLoaded', function() { setDocDataHeight(); });" %>
+<%= javascript_tag "$(window).resize(function() { setDocDataHeight(); });" %>
 
 <div id='game-info' class="container">
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,21 +4,21 @@
     <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
     <%= render "layouts/shim" %>
   </head>
 
   <body>
     <%= render "layouts/header" %>
+
     <div class="main-container container">
       <% flash.each do |message_type, message| %>
       <div class="<%= flash_class(message_type) %>"><%= message %></div>
-<!-- =======
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
->>>>>>> Add home page -->
       <% end %>
+
       <%= yield %>
+
       <%= render "layouts/footer" %>
       <%= debug(params) if Rails.env.development? %>
     </div>

--- a/spec/features/play_game_spec.rb
+++ b/spec/features/play_game_spec.rb
@@ -1,4 +1,8 @@
 require "rails_helper"
+require_relative "shared_examples/reader"
+require_relative "shared_examples/whiteboard"
+require_relative "shared_examples/game_attributes"
+
 ROUND = 42
 SCORE = 1024
 
@@ -20,28 +24,9 @@ RSpec.describe 'Players can play the game' do
         visit game_path(game)
       end
 
-      it 'should see attibutes but no Questioner' do
-        within("#attributes") do
-          expect(page).not_to have_content "Questioner of this round: "
-          expect(page).to have_content "judge"
-          expect(page).to have_content @game_player.round.to_s
-          expect(page).to have_content @game_player.score.to_s
-        end
-      end
-
-      it 'should see reading text' do
-        within("#document") do
-          within("header h2") do
-            expect(page).to have_content "Reading Text"
-          end
-
-          within(".document") do
-            expect(page).to have_content "dummy title"
-            expect(page).to have_content "This is a single dummy document meant to be tested by rspec.
-            This document should not be used under any other conditions."
-          end
-        end
-      end
+      it_behaves_like 'reader'
+      include_examples 'whiteboard'
+      include_examples 'game_attributes', :judge, 'not questioner'
     end
 
     context 'as a reader' do
@@ -51,28 +36,9 @@ RSpec.describe 'Players can play the game' do
         visit game_path(game)
       end
 
-      it 'should see attributes' do
-        within("#attributes") do
-          expect(page).to have_content "Questioner of this round: "
-          expect(page).to have_content "reader"
-          expect(page).to have_content @game_player.round.to_s
-          expect(page).to have_content @game_player.score.to_s
-        end
-      end
-
-      it 'should see reading text' do
-        within("#document") do
-          within("header h2") do
-            expect(page).to have_content "Reading Text"
-          end
-
-          within(".document") do
-            expect(page).to have_content "dummy title"
-            expect(page).to have_content "This is a single dummy document meant to be tested by rspec.
-            This document should not be used under any other conditions."
-          end
-        end
-      end
+      it_behaves_like 'reader'
+      include_examples 'whiteboard'
+      include_examples 'game_attributes', :reader, 'questioner'
     end
 
     context 'as a guesser' do
@@ -82,23 +48,17 @@ RSpec.describe 'Players can play the game' do
         visit game_path(game)
       end
 
-      it 'should see attributes' do
-          within("#attributes") do
-          expect(page).to have_content "Questioner of this round: "
-          expect(page).to have_content "guesser"
-          expect(page).to have_content @game_player.round.to_s
-          expect(page).to have_content @game_player.score.to_s
-        end
-      end
-
-      it 'should not see reading text' do
+      it 'should not see the document content' do
         expect(page).not_to have_selector "#document"
-        expect(page).not_to have_content "Reading Text"
+        expect(page).not_to have_content "Document"
 
         expect(page).not_to have_content "dummy title"
         expect(page).not_to have_content "This is a single dummy document meant to be tested by rspec.
         This document should not be used under any other conditions."
       end
+
+      include_examples 'whiteboard'
+      include_examples 'game_attributes', :guesser, 'questioner'
     end
   end
 

--- a/spec/features/shared_examples/game_attributes.rb
+++ b/spec/features/shared_examples/game_attributes.rb
@@ -1,0 +1,30 @@
+RSpec.shared_examples "general_attributes" do |role|
+  it 'should see general attributes' do
+    within("#attributes") do
+      expect(page).to have_content "#{role}"
+      expect(page).to have_content @game_player.round.to_s
+      expect(page).to have_content @game_player.score.to_s
+    end
+  end
+end
+
+RSpec.shared_examples "questioner" do
+  it 'should see questioner' do
+    within("#attributes") do
+      expect(page).to have_content "Questioner of this round: "
+    end
+  end
+end
+
+RSpec.shared_examples "not questioner" do
+  it 'should not see questioner' do
+    within("#attributes") do
+      expect(page).not_to have_content "Questioner of this round: "
+    end
+  end
+end
+
+RSpec.shared_examples "game_attributes" do |role, questioner_role|
+  include_examples 'general_attributes', role
+  include_examples questioner_role
+end

--- a/spec/features/shared_examples/reader.rb
+++ b/spec/features/shared_examples/reader.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples "reader" do
+  it 'should see the document content' do
+    within(".titles") do
+      expect(page).to have_content "Document"
+    end
+
+    within(".doc-info") do
+      expect(page).to have_content "dummy title"
+      expect(page).to have_content "This is a single dummy document meant to be tested by rspec.
+      This document should not be used under any other conditions."
+    end
+  end
+end

--- a/spec/features/shared_examples/whiteboard.rb
+++ b/spec/features/shared_examples/whiteboard.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "whiteboard" do
+  it 'should see the whiteboard content' do
+    within(".titles") do
+      expect(page).to have_content "Whiteboard"
+    end
+  end
+end


### PR DESCRIPTION
* Display `document` and `whiteboard` data alongside with columns. (Whiteboard is currently an example).
* Calculate the height of the columns as a percentage of pixels with respect to the window height and activate scrollbars if the content overflows. (Currently set to 50% of the window height).
* Update specs.

Closes https://github.com/Xiaohong-Deng/mooqita-icccg/issues/56
Related to https://github.com/Xiaohong-Deng/mooqita-icccg/issues/44

![image](https://user-images.githubusercontent.com/92138/30731654-47f08742-9f34-11e7-80f0-4252d334cbdd.png)